### PR TITLE
Fix#282-profile-dropdown-fix-to-right

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -1,3 +1,11 @@
+@media screen and (max-width: 900px) {
+  .openProfile {
+    left: 0 !important;
+    right: auto !important;
+  }
+}
+
+
 header {
   background: #ffa9cb;
   padding: 15px 20px;
@@ -36,7 +44,6 @@ header {
   width: 100%;
 }
 
-
 .nav-link {
   text-transform: capitalize;
   color: #000;
@@ -44,7 +51,6 @@ header {
   padding: 10px;
   margin: 20px;
   transition: all 0.3s ease;
-
 }
 
 .nav-link::after {


### PR DESCRIPTION
This Pr fixes issue #282 .

1. Ensures the profile dropdown menu opens to the right of the profile icon when the header wraps and the icon appears on a new row (e.g., on tablet or small desktop screens).
2. Adds a CSS media query to force the dropdown alignment (left: 0 !important; right: auto !important;) for .openProfile at screen widths ≤900px.
3. Prevents the dropdown from being clipped or rendered off-screen on intermediate screen sizes.
4. No changes to desktop or mobile hamburger menu behavior. This improves accessibility and usability of the profile dropdown on all screen sizes.

<img width="857" height="838" alt="image" src="https://github.com/user-attachments/assets/bb044c89-5867-44ca-8b4d-b39f82f8daf8" />
