### PR TITLE
UI Enhancement: Updated Audio Card Styling

### DIFF
--- a/src/pages/music/calmingCorner.css
+++ b/src/pages/music/calmingCorner.css
@@ -87,6 +87,22 @@
 .track-item audio {
   width: 100%;
   height: 32px;
+  /* Styling for audio controls */
+  accent-color: #a8a0e8; /* A soft, calming shade */
+}
+
+.track-item audio::-webkit-media-controls-panel {
+  background-color: transparent; /* Keep the panel background transparent */
+}
+
+.track-item audio::-webkit-media-controls-play-button,
+.track-item audio::-webkit-media-controls-current-time-display,
+.track-item audio::-webkit-media-controls-time-remaining-display,
+.track-item audio::-webkit-media-controls-timeline,
+.track-item audio::-webkit-media-controls-volume-slider,
+.track-item audio::-webkit-media-controls-toggle-closed-captions-button,
+.track-item audio::-webkit-media-controls-fullscreen-button {
+  color: #a8a0e8; /* Apply the calming shade to all controls */
 }
 
 .show-more {


### PR DESCRIPTION
🔄 Changes Made

1-Restyled the audio player controls inside the audio cards:
2-Replaced the default black controls (play button, progress bar, volume icon) that were clashing with the theme.
3-Applied softer, theme-consistent colors to match the calming aesthetic of Calming Corner.
<img width="454" height="797" alt="image" src="https://github.com/user-attachments/assets/e00f7713-a5d8-4fd1-b530-df169a21d668" />
